### PR TITLE
Fix gift flow UX and reserved subscription handling

### DIFF
--- a/bot/src/api.ts
+++ b/bot/src/api.ts
@@ -721,7 +721,7 @@ export async function buyGiftSubscription(
 export async function getGiftSubscriptions(
   token: string
 ): Promise<{ subscriptions: { id: string; remnawaveUuid: string | null; subscriptionIndex: number | null; giftStatus: string | null; ownerId: string }[] }> {
-  return fetchJson("/api/client/gift/subscriptions", { token });
+  return fetchJson("/api/client/gift/subscriptions/all", { token });
 }
 
 /** Создать подарочный код */

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -325,6 +325,31 @@ function getSubUser(sub: unknown): Record<string, unknown> | null {
   return r;
 }
 
+function buildGiftShareMarkup(
+  codeId: string,
+  code: string,
+  tariffName: string | null | undefined,
+  config: Awaited<ReturnType<typeof api.getPublicConfig>>,
+): { inline_keyboard: (({ text: string; callback_data: string } | { text: string; url: string })[])[] } {
+  const appUrl = config?.publicAppUrl?.replace(/\/$/, "") ?? "";
+  const giftUrl = appUrl ? `${appUrl}/gift/${code}` : "";
+  const shareText = `🎁 Я дарю тебе VPN-подписку STEALTHNET${tariffName ? ` (${tariffName})` : ""}! Активируй по ссылке:`;
+  const shareUrl = giftUrl
+    ? `https://t.me/share/url?url=${encodeURIComponent(giftUrl)}&text=${encodeURIComponent(shareText)}`
+    : "";
+  const buttons: (({ text: string; callback_data: string } | { text: string; url: string })[])[] = [];
+  if (shareUrl) {
+    buttons.push([{ text: "📤 Поделиться в Telegram", url: shareUrl }]);
+  }
+  if (giftUrl) {
+    buttons.push([{ text: "🔗 Ссылка на подарок", url: giftUrl }]);
+  }
+  buttons.push([{ text: "❌ Отменить подарок", callback_data: `gift:cancel_code:${codeId}` }]);
+  buttons.push([{ text: "📋 К подпискам", callback_data: "gift:subscriptions" }]);
+  buttons.push([{ text: config?.botBackLabel ?? "← Назад", callback_data: "menu:gift" }]);
+  return { inline_keyboard: buttons };
+}
+
 function bytesToGb(bytes: number): string {
   return (bytes / (1024 * 1024 * 1024)).toFixed(2);
 }
@@ -2978,7 +3003,10 @@ bot.on("callback_query:data", async (ctx) => {
 
     if (data === "gift:subscriptions") {
       try {
-        const result = await api.getGiftSubscriptions(token);
+        const [result, codesResult] = await Promise.all([
+          api.getGiftSubscriptions(token),
+          api.getGiftCodes(token),
+        ]);
         if (!result.subscriptions?.length) {
           await editMessageContent(
             ctx,
@@ -2987,10 +3015,15 @@ bot.on("callback_query:data", async (ctx) => {
           );
           return;
         }
+        const activeCodeIdsBySubscriptionId = Object.fromEntries(
+          (codesResult.codes ?? [])
+            .filter((code) => code.status === "ACTIVE")
+            .map((code) => [code.secondarySubscriptionId, code.id]),
+        );
         await editMessageContent(
           ctx,
-          `📋 Мои подписки\n\nУ вас ${result.subscriptions.length} доп. подписок:`,
-          giftSubscriptionButtons(result.subscriptions, config?.botBackLabel ?? null, innerStyles, innerEmojiIds),
+          "📋 Мои подписки\n\nЗдесь видно все дополнительные подписки: доступные, уже подаренные и те, для которых код уже создан.",
+          giftSubscriptionButtons(result.subscriptions, activeCodeIdsBySubscriptionId, config?.botBackLabel ?? null, innerStyles, innerEmojiIds),
         );
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Ошибка загрузки";
@@ -3057,31 +3090,48 @@ bot.on("callback_query:data", async (ctx) => {
         const result = await api.createGiftCode(token, { secondarySubscriptionId: subscriptionId });
         const expiresAt = new Date(result.expiresAt).toLocaleDateString("ru-RU");
         const tariffLabel = result.tariffName ? `\nТариф: ${result.tariffName}` : "";
-
-        // Формируем ссылку на подарок и кнопку "Поделиться"
-        const appUrl = config?.publicAppUrl?.replace(/\/$/, "") ?? "";
-        const giftUrl = appUrl ? `${appUrl}/gift/${result.code}` : "";
-        const shareText = `🎁 Я дарю тебе VPN-подписку STEALTHNET${result.tariffName ? ` (${result.tariffName})` : ""}! Активируй по ссылке:`;
-        const shareUrl = giftUrl
-          ? `https://t.me/share/url?url=${encodeURIComponent(giftUrl)}&text=${encodeURIComponent(shareText)}`
-          : "";
-
-        const buttons: (({ text: string; callback_data: string } | { text: string; url: string })[])[] = [];
-        if (shareUrl) {
-          buttons.push([{ text: "📤 Поделиться в Telegram", url: shareUrl }]);
-        }
-        if (giftUrl) {
-          buttons.push([{ text: "🔗 Ссылка на подарок", url: giftUrl }]);
-        }
-        buttons.push([{ text: config?.botBackLabel ?? "← Назад", callback_data: "menu:gift" }]);
+        const codes = await api.getGiftCodes(token);
+        const activeCode = codes.codes.find(
+          (code) => code.secondarySubscriptionId === subscriptionId && code.code === result.code && code.status === "ACTIVE",
+        );
+        const buttons = buildGiftShareMarkup(activeCode?.id ?? result.code, result.code, result.tariffName, config);
 
         await editMessageContent(
           ctx,
           `🎁 Подарочный код создан!\n\nКод: \`${result.code}\`${tariffLabel}\n\nОтправьте этот код получателю или поделитесь ссылкой. Код действителен до ${expiresAt}.`,
-          { inline_keyboard: buttons },
+          { inline_keyboard: buttons.inline_keyboard },
         );
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Ошибка создания кода";
+        await editMessageContent(ctx, `❌ ${msg}`, backToMenu(config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds));
+      }
+      return;
+    }
+
+    if (data.startsWith("gift:show_code:")) {
+      const subscriptionId = data.slice("gift:show_code:".length);
+      try {
+        const codes = await api.getGiftCodes(token);
+        const activeCode = codes.codes.find(
+          (code) => code.secondarySubscriptionId === subscriptionId && code.status === "ACTIVE",
+        );
+        if (!activeCode) {
+          await editMessageContent(
+            ctx,
+            "❌ Для этой подписки активный подарочный код не найден.",
+            giftCodeResultButtons(config?.botBackLabel ?? null, innerStyles, innerEmojiIds),
+          );
+          return;
+        }
+        const expiresAt = new Date(activeCode.expiresAt).toLocaleDateString("ru-RU");
+        const buttons = buildGiftShareMarkup(activeCode.id, activeCode.code, null, config);
+        await editMessageContent(
+          ctx,
+          `🎟️ Подарок уже создан.\n\nКод: \`${activeCode.code}\`\n\nПоделитесь кодом или ссылкой. Код действителен до ${expiresAt}.`,
+          { inline_keyboard: buttons.inline_keyboard },
+        );
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "Ошибка загрузки подарка";
         await editMessageContent(ctx, `❌ ${msg}`, backToMenu(config?.botBackLabel ?? null, innerStyles?.back, innerEmojiIds));
       }
       return;

--- a/bot/src/keyboard.ts
+++ b/bot/src/keyboard.ts
@@ -725,6 +725,7 @@ export function giftMenuButtons(
 /** Список вторичных подписок с кнопками «Подключить» и «Подарить» */
 export function giftSubscriptionButtons(
   subscriptions: { id: string; subscriptionIndex: number | null; giftStatus: string | null }[],
+  activeCodeIdsBySubscriptionId: Record<string, string>,
   backLabel?: string | null,
   innerStyles?: InnerButtonStyles,
   emojiIds?: InnerEmojiIds
@@ -734,6 +735,7 @@ export function giftSubscriptionButtons(
   const rows: InlineButton[][] = [];
   for (const sub of subscriptions) {
     const idx = sub.subscriptionIndex ?? 0;
+    const activeCodeId = activeCodeIdsBySubscriptionId[sub.id];
     const statusLabel =
       sub.giftStatus === "GIFTED"
         ? " (подарена)"
@@ -742,6 +744,16 @@ export function giftSubscriptionButtons(
           : sub.giftStatus === "ACTIVATED_SELF"
             ? " (для себя)"
             : "";
+    if (sub.giftStatus === "GIFT_RESERVED") {
+      rows.push([
+        btn(`🎟️ Подарок #${idx}${statusLabel}`, `gift:show_code:${sub.id}`, "primary", emojiIds?.card),
+      ]);
+      rows.push([
+        btn(`✅ Оставить себе #${idx}`, `gift:connect:${sub.id}`, "primary", emojiIds?.connect),
+        btn(`❌ Отменить подарок #${idx}`, activeCodeId ? `gift:cancel_code:${activeCodeId}` : "gift:codes", "danger"),
+      ]);
+      continue;
+    }
     // Кнопка «Подключить» нужна и для ACTIVATED_SELF — иначе при нескольких таких подписках
     // остаётся только «Назад», без страницы подписки / Remna.
     rows.push([

--- a/frontend/src/pages/cabinet/client-gifts.tsx
+++ b/frontend/src/pages/cabinet/client-gifts.tsx
@@ -598,6 +598,13 @@ export function ClientGiftsPage() {
                 const isReserved = sub.giftStatus === "GIFT_RESERVED";
                 const activeCode = codes.find(c => c.secondarySubscriptionId === sub.id && c.status === "ACTIVE");
                 const isFinalized = isGifted || isActivatedSelf;
+                const statusText = isGifted
+                  ? "Эта подписка была подарена вам."
+                  : isActivatedSelf
+                    ? "Эта подписка была активирована вами."
+                    : isReserved
+                      ? "Подарок уже создан. Можно скопировать код или ссылку, отменить подарок либо оставить подписку себе."
+                      : "Доступна для подарка или активации себе.";
 
                 return (
                   <motion.div
@@ -612,7 +619,7 @@ export function ClientGiftsPage() {
                       <div>
                         <h3 className="text-xl font-bold text-foreground">Подписка #{sub.subscriptionIndex}</h3>
                         <p className="text-sm text-muted-foreground mt-1 max-w-[240px]">
-                          {isGifted ? "Эта подписка была подарена вам." : isActivatedSelf ? "Эта подписка была активирована вами." : isReserved ? "Для подписки создан код." : "Доступна для подарка или активации себе."}
+                          {statusText}
                         </p>
                       </div>
                       <span className={`shrink-0 rounded-full px-3 py-1.5 text-xs font-semibold ${isGifted ? 'bg-purple-500/15 text-purple-500 border border-purple-500/20' : isActivatedSelf ? 'bg-blue-500/15 text-blue-500 border border-blue-500/20' : isReserved ? 'bg-amber-500/15 text-amber-500 border border-amber-500/20' : 'bg-green-500/15 text-green-500 border border-green-500/20'}`}>
@@ -634,44 +641,65 @@ export function ClientGiftsPage() {
                         <CheckCircle2 className="w-5 h-5 text-green-500" />
                         <span className="text-sm font-semibold text-green-600 dark:text-green-400">Активирована</span>
                       </div>
+                    ) : isReserved ? (
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-auto">
+                        <Button
+                          variant="secondary"
+                          className="rounded-xl bg-primary/10 hover:bg-primary/20 text-primary border-none shadow-none w-full gap-2"
+                          onClick={() => handleGetUrl(sub)}
+                          disabled={!activeCode || actionLoading === `url-${sub.id}`}
+                        >
+                          {actionLoading === `url-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : copiedId === `url-${sub.id}` ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
+                          Скопировать ссылку
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          className="rounded-xl bg-background/70 hover:bg-muted text-foreground border border-border/60 shadow-none w-full gap-2"
+                          onClick={() => activeCode && copyCode(activeCode.code, activeCode.id)}
+                          disabled={!activeCode}
+                        >
+                          {activeCode && copiedId === `code-${activeCode.id}` ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
+                          Скопировать код
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          className="rounded-xl bg-green-500/10 hover:bg-green-500/20 text-green-600 dark:text-green-400 font-semibold border-none shadow-none w-full gap-2"
+                          onClick={() => handleActivateForSelf(sub.id)}
+                          disabled={actionLoading === `activate-${sub.id}`}
+                        >
+                          {actionLoading === `activate-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                          Оставить себе
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          className="rounded-xl bg-destructive/10 text-destructive hover:bg-destructive hover:text-destructive-foreground border-none shadow-none w-full gap-2"
+                          onClick={() => activeCode && handleCancelCode(activeCode.id)}
+                          disabled={!activeCode || actionLoading === `cancel-${activeCode.id}`}
+                        >
+                          {activeCode && actionLoading === `cancel-${activeCode.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <XCircle className="w-4 h-4" />}
+                          Отменить подарок
+                        </Button>
+                      </div>
                     ) : (
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-auto">
-                      <Button 
-                        className="rounded-xl shadow-md w-full gap-2"
-                        onClick={() => handleCreateCode(sub.id)}
-                        disabled={isReserved || actionLoading === `create-${sub.id}`}
-                      >
-                        {actionLoading === `create-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <Gift className="w-4 h-4" />}
-                        Подарить
-                      </Button>
-                      <Button 
-                        variant="secondary" 
-                        className="rounded-xl bg-primary/10 hover:bg-primary/20 text-primary border-none shadow-none w-full gap-2"
-                        onClick={() => handleGetUrl(sub)}
-                        disabled={!activeCode || actionLoading === `url-${sub.id}`}
-                      >
-                        {actionLoading === `url-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : copiedId === `url-${sub.id}` ? <Check className="w-4 h-4" /> : <LinkIcon className="w-4 h-4" />}
-                        Ссылка
-                      </Button>
-                      <Button 
-                        variant="secondary" 
-                        className="rounded-xl bg-green-500/10 hover:bg-green-500/20 text-green-600 dark:text-green-400 font-semibold border-none shadow-none w-full gap-2"
-                        onClick={() => handleActivateForSelf(sub.id)}
-                        disabled={actionLoading === `activate-${sub.id}`}
-                      >
-                        {actionLoading === `activate-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
-                        Активировать себе
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        className="rounded-xl bg-destructive/10 text-destructive hover:bg-destructive hover:text-destructive-foreground border-none shadow-none w-full gap-2"
-                        onClick={() => activeCode && handleCancelCode(activeCode.id)}
-                        disabled={!activeCode || actionLoading === `cancel-${activeCode.id}`}
-                      >
-                        {activeCode && actionLoading === `cancel-${activeCode.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <XCircle className="w-4 h-4" />}
-                        Отменить код
-                      </Button>
-                    </div>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-auto">
+                        <Button
+                          className="rounded-xl shadow-md w-full gap-2"
+                          onClick={() => handleCreateCode(sub.id)}
+                          disabled={actionLoading === `create-${sub.id}`}
+                        >
+                          {actionLoading === `create-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <Gift className="w-4 h-4" />}
+                          Подарить
+                        </Button>
+                        <Button
+                          variant="secondary"
+                          className="rounded-xl bg-green-500/10 hover:bg-green-500/20 text-green-600 dark:text-green-400 font-semibold border-none shadow-none w-full gap-2"
+                          onClick={() => handleActivateForSelf(sub.id)}
+                          disabled={actionLoading === `activate-${sub.id}`}
+                        >
+                          {actionLoading === `activate-${sub.id}` ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+                          Активировать себе
+                        </Button>
+                      </div>
                     )}
                   </motion.div>
                 );


### PR DESCRIPTION
## What changed
- keep gift-reserved subscriptions visible in the bot subscriptions list
- add dedicated bot actions for an already-created gift: open it, cancel it, or keep it for yourself
- simplify the cabinet gift card state so a created gift shows clear follow-up actions instead of a disabled `Подарить` button

## Why
The gift flow was confusing in two places:
- in the bot, a subscription appeared to lose the gift action after creating a gift because `GIFT_RESERVED` subscriptions were hidden from the list
- in the cabinet, the created-gift state looked broken because the primary action stayed visible but disabled

## Impact
- users can manage created gifts directly from the same subscription entry
- the `Подарить` flow is linear and easier to understand
- gift cancellation and self-activation are easier to discover

## Validation
- `frontend`: `npm run build`
