### PR TITLE
Вход по коду с почты + сброс пароля, не тестил

### DIFF
--- a/backend/prisma/migrations/20260430120000_email_code_and_password_reset/migration.sql
+++ b/backend/prisma/migrations/20260430120000_email_code_and_password_reset/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "pending_email_login_codes" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "code_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "pending_email_login_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "pending_password_resets" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "pending_password_resets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "pending_email_login_codes_email_idx" ON "pending_email_login_codes"("email");
+CREATE INDEX "pending_email_login_codes_expires_at_idx" ON "pending_email_login_codes"("expires_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "pending_password_resets_token_key" ON "pending_password_resets"("token");
+CREATE INDEX "pending_password_resets_email_idx" ON "pending_password_resets"("email");
+CREATE INDEX "pending_password_resets_expires_at_idx" ON "pending_password_resets"("expires_at");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -217,6 +217,32 @@ model PendingEmailRegistration {
   @@map("pending_email_registrations")
 }
 
+model PendingEmailLoginCode {
+  id         String   @id @default(cuid())
+  email      String
+  codeHash   String   @map("code_hash")
+  expiresAt  DateTime @map("expires_at")
+  attempts   Int      @default(0)
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([email])
+  @@index([expiresAt])
+  @@map("pending_email_login_codes")
+}
+
+model PendingPasswordReset {
+  id         String   @id @default(cuid())
+  token      String   @unique
+  email      String
+  expiresAt  DateTime @map("expires_at")
+  usedAt     DateTime? @map("used_at")
+  createdAt  DateTime @default(now()) @map("created_at")
+
+  @@index([email])
+  @@index([expiresAt])
+  @@map("pending_password_resets")
+}
+
 model Payment {
   id                    String    @id @default(cuid())
   clientId              String    @map("client_id")

--- a/backend/src/modules/client/client.routes.ts
+++ b/backend/src/modules/client/client.routes.ts
@@ -1,4 +1,4 @@
-import { randomBytes, createHmac } from "crypto";
+import { randomBytes, createHmac, createHash } from "crypto";
 import { randomUUID } from "crypto";
 import { generateSecret, generateURI, verify } from "otplib";
 import { env } from "../../config/index.js";
@@ -25,7 +25,7 @@ import {
 } from "../notification/telegram-notify.service.js";
 import { requireClientAuth } from "./client.middleware.js";
 import { remnaCreateUser, remnaUpdateUser, isRemnaConfigured, remnaGetUser, remnaGetUserByUsername, remnaGetUserByEmail, remnaGetUserByTelegramId, extractRemnaUuid, remnaUsernameFromClient, remnaGetUserHwidDevices, remnaDeleteUserHwidDevice } from "../remna/remna.client.js";
-import { sendVerificationEmail, sendLinkEmailVerification, isSmtpConfigured } from "../mail/mail.service.js";
+import { sendVerificationEmail, sendLinkEmailVerification, isSmtpConfigured, sendEmail } from "../mail/mail.service.js";
 import { createPlategaTransaction, isPlategaConfigured } from "../platega/platega.service.js";
 import { activateTariffForClient, activateTariffByPaymentId } from "../tariff/tariff-activation.service.js";
 import { saveRedirectAndBuildUrl } from "../payment-redirect/payment-redirect.util.js";
@@ -359,9 +359,93 @@ clientAuthRouter.post("/verify-email", async (req, res) => {
   return res.status(201).json({ token: signToken, client: toClientShape(client) });
 });
 
+
+function hashOneTime(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
 const loginSchema = z.object({
   email: z.string().email(),
   password: z.string().min(1),
+});
+
+
+const emailCodeRequestSchema = z.object({ email: z.string().email() });
+clientAuthRouter.post("/login-email-code/request", async (req, res) => {
+  const body = emailCodeRequestSchema.safeParse(req.body);
+  if (!body.success) return res.status(400).json({ message: "Invalid input" });
+  const config = await getSystemConfig();
+  const enabled = config.loginEmailCodeEnabled !== false;
+  if (!enabled) return res.status(403).json({ message: "Login by email code is disabled" });
+  const client = await prisma.client.findUnique({ where: { email: body.data.email } });
+  if (!client || client.isBlocked) return res.json({ success: true });
+  const smtpConfig = { host: config.smtpHost || "", port: config.smtpPort, secure: config.smtpSecure, user: config.smtpUser, password: config.smtpPassword, fromEmail: config.smtpFromEmail, fromName: config.smtpFromName };
+  if (!isSmtpConfigured(smtpConfig)) return res.status(503).json({ message: "SMTP not configured" });
+  const code = String(Math.floor(100000 + Math.random() * 900000));
+  const email = body.data.email.toLowerCase();
+  await prisma.pendingEmailLoginCode.deleteMany({ where: { email } });
+  await prisma.pendingEmailLoginCode.create({
+    data: {
+      email,
+      codeHash: hashOneTime(code),
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+    },
+  });
+  await sendEmail(smtpConfig, body.data.email, `Код входа — ${config.serviceName || "STEALTHNET"}`, `<p>Ваш код входа: <b>${code}</b></p><p>Код действителен 10 минут.</p>`);
+  return res.json({ success: true });
+});
+
+const emailCodeLoginSchema = z.object({ email: z.string().email(), code: z.string().length(6) });
+clientAuthRouter.post("/login-email-code", async (req, res) => {
+  const body = emailCodeLoginSchema.safeParse(req.body);
+  if (!body.success) return res.status(400).json({ message: "Invalid input" });
+  const email = body.data.email.toLowerCase();
+  const rec = await prisma.pendingEmailLoginCode.findFirst({
+    where: { email },
+    orderBy: { createdAt: "desc" },
+  });
+  if (!rec || rec.expiresAt < new Date() || rec.codeHash !== hashOneTime(body.data.code)) {
+    if (rec) await prisma.pendingEmailLoginCode.update({ where: { id: rec.id }, data: { attempts: { increment: 1 } } }).catch(() => {});
+    return res.status(401).json({ message: "Invalid code" });
+  }
+  const client = await prisma.client.findUnique({ where: { email: body.data.email } });
+  if (!client || client.isBlocked) return res.status(401).json({ message: "Invalid code" });
+  await prisma.pendingEmailLoginCode.deleteMany({ where: { email } });
+  const full = await prisma.client.findUnique({ where: { id: client.id }, select: { id: true, email: true, telegramId: true, telegramUsername: true, preferredLang: true, preferredCurrency: true, balance: true, referralCode: true, referralPercent: true, remnawaveUuid: true, trialUsed: true, isBlocked: true, autoRenewEnabled: true, autoRenewTariffId: true, yoomoneyAccessToken: true, totpEnabled: true, createdAt: true, onboardingCompleted: true } });
+  if (!full) return res.status(401).json({ message: "Invalid code" });
+  return res.json(buildAuthResponse(full));
+});
+
+clientAuthRouter.post("/password-reset/request", async (req, res) => {
+  const body = emailCodeRequestSchema.safeParse(req.body);
+  if (!body.success) return res.status(400).json({ message: "Invalid input" });
+  const config = await getSystemConfig();
+  const smtpConfig = { host: config.smtpHost || "", port: config.smtpPort, secure: config.smtpSecure, user: config.smtpUser, password: config.smtpPassword, fromEmail: config.smtpFromEmail, fromName: config.smtpFromName };
+  if (!isSmtpConfigured(smtpConfig)) return res.status(503).json({ message: "SMTP not configured" });
+  const client = await prisma.client.findUnique({ where: { email: body.data.email } });
+  if (!client || client.isBlocked) return res.json({ success: true });
+  const token = randomBytes(32).toString("hex");
+  const email = body.data.email.toLowerCase();
+  await prisma.pendingPasswordReset.create({
+    data: { token, email, expiresAt: new Date(Date.now() + 60 * 60_000) },
+  });
+  const appUrl = (config.publicAppUrl || "").replace(/\/$/, "");
+  const link = `${appUrl}/cabinet/reset-password?token=${token}`;
+  await sendEmail(smtpConfig, body.data.email, `Сброс пароля — ${config.serviceName || "STEALTHNET"}`, `<p>Для сброса пароля перейдите по ссылке:</p><p><a href="${link}">${link}</a></p><p>Ссылка действительна 1 час.</p>`);
+  return res.json({ success: true });
+});
+
+  const resetPasswordSchema = z.object({ token: z.string().min(1), password: z.string().min(6) });
+clientAuthRouter.post("/password-reset/confirm", async (req, res) => {
+  const body = resetPasswordSchema.safeParse(req.body);
+  if (!body.success) return res.status(400).json({ message: "Invalid input" });
+  const rec = await prisma.pendingPasswordReset.findUnique({ where: { token: body.data.token } });
+  if (!rec || rec.usedAt || rec.expiresAt < new Date()) return res.status(400).json({ message: "Invalid or expired token" });
+  const passwordHash = await hashPassword(body.data.password);
+  const client = await prisma.client.update({ where: { email: rec.email }, data: { passwordHash }, select: { id: true } }).catch(() => null);
+  await prisma.pendingPasswordReset.update({ where: { id: rec.id }, data: { usedAt: new Date() } }).catch(() => {});
+  if (!client) return res.status(400).json({ message: "Invalid token" });
+  return res.json({ token: signClientToken(client.id) });
 });
 
 clientAuthRouter.post("/login", async (req, res) => {
@@ -4866,6 +4950,5 @@ publicConfigRouter.get("/singbox-tariffs", async (_req, res) => {
     return res.status(500).json({ message: "Ошибка загрузки тарифов Sing-box" });
   }
 });
-
 
 

--- a/backend/src/modules/client/client.service.ts
+++ b/backend/src/modules/client/client.service.ts
@@ -132,6 +132,7 @@ const SYSTEM_CONFIG_KEYS = [
   "google_analytics_id", "yandex_metrika_id", // Маркетинг: счётчики для кабинета
   "auto_broadcast_cron", // Расписание авто-рассылки (cron, например "0 9 * * *" = 9:00 каждый день)
   "skip_email_verification", // Регистрация без подтверждения почты: true/false
+  "login_email_code_enabled", // Вход по коду из email: true/false
   "use_remna_subscription_page", // Кнопка VPN в боте ведёт на страницу подписки Remna вместо кабинета: true/false
   "ai_chat_enabled", // AI-чат в кабинете включён: true/false
   // Гибкий тариф (собери сам): цена за день, устройство, трафик или безлимит, сквад
@@ -534,6 +535,7 @@ export async function getSystemConfig() {
     groqFallback3: (map.groq_fallback_3 ?? "").trim() || null,
     aiSystemPrompt: map.ai_system_prompt || "Ты — лучший менеджер техподдержки VPN-сервиса. Твоя цель — вежливо, быстро и точно помогать пользователям с настройкой VPN, тарифами и решением технических проблем. Отвечай кратко и по делу.",
     skipEmailVerification: map.skip_email_verification === "true" || map.skip_email_verification === "1",
+    loginEmailCodeEnabled: map.login_email_code_enabled !== "false" && map.login_email_code_enabled !== "0",
     useRemnaSubscriptionPage: map.use_remna_subscription_page === "true" || map.use_remna_subscription_page === "1",
     aiChatEnabled: map.ai_chat_enabled !== "false" && map.ai_chat_enabled !== "0",
     customBuildEnabled: map.custom_build_enabled === "true" || map.custom_build_enabled === "1",
@@ -1006,6 +1008,7 @@ export async function getPublicConfig() {
     ),
     paymentProviders: full.paymentProviders,
     skipEmailVerification: full.skipEmailVerification ?? false,
+    loginEmailCodeEnabled: full.loginEmailCodeEnabled ?? true,
     useRemnaSubscriptionPage: full.useRemnaSubscriptionPage ?? false,
     aiChatEnabled: full.aiChatEnabled ?? true,
     trialEnabled,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import { ClientRegisterPage } from "@/pages/cabinet/client-register";
 import { ClientOnboardingPage } from "@/pages/cabinet/client-onboarding";
 import { ClientVerifyEmailPage } from "@/pages/cabinet/client-verify-email";
 import { ClientVerifyLinkEmailPage } from "@/pages/cabinet/client-verify-link-email";
+import { ClientResetPasswordPage } from "@/pages/cabinet/client-reset-password";
 import { ClientDashboardPage } from "@/pages/cabinet/client-dashboard";
 import { ClientTariffsPage } from "@/pages/cabinet/client-tariffs";
 import { ClientProfilePage } from "@/pages/cabinet/client-profile";
@@ -261,6 +262,7 @@ function AppRoutes() {
         <Route path="login" element={<ClientLoginPage />} />
         <Route path="register" element={<ClientRegisterPage />} />
         <Route path="verify-email" element={<ClientVerifyEmailPage />} />
+        <Route path="reset-password" element={<ClientResetPasswordPage />} />
         <Route path="verify-link-email" element={<ClientVerifyLinkEmailPage />} />
         <Route
           path="dashboard"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1293,6 +1293,23 @@ export const api = {
     });
   },
 
+  
+  async clientRequestEmailLoginCode(email: string): Promise<{ success: boolean }> {
+    return request("/client/auth/login-email-code/request", { method: "POST", body: JSON.stringify({ email }) });
+  },
+
+  async clientLoginByEmailCode(email: string, code: string): Promise<ClientAuthResponse | ClientAuthRequires2FA> {
+    return request("/client/auth/login-email-code", { method: "POST", body: JSON.stringify({ email, code }) });
+  },
+
+  async clientRequestPasswordReset(email: string): Promise<{ success: boolean }> {
+    return request("/client/auth/password-reset/request", { method: "POST", body: JSON.stringify({ email }) });
+  },
+
+  async clientConfirmPasswordReset(token: string, password: string): Promise<{ token: string }> {
+    return request("/client/auth/password-reset/confirm", { method: "POST", body: JSON.stringify({ token, password }) });
+  },
+
   async clientMe(token: string): Promise<ClientProfile> {
     return request("/client/auth/me", { token });
   },
@@ -2117,6 +2134,7 @@ export type UpdateSettingsPayload = {
   autoBroadcastCron?: string | null;
   adminFrontNotificationsEnabled?: boolean;
   skipEmailVerification?: boolean;
+  loginEmailCodeEnabled?: boolean;
   useRemnaSubscriptionPage?: boolean;
   aiChatEnabled?: boolean;
   customBuildEnabled?: boolean;
@@ -2492,6 +2510,7 @@ export interface AdminSettings {
   adminFrontNotificationsEnabled?: boolean;
   /** Регистрация без подтверждения почты */
   skipEmailVerification?: boolean;
+  loginEmailCodeEnabled?: boolean;
   /** Кнопка VPN в боте ведёт на страницу подписки Remna */
   useRemnaSubscriptionPage?: boolean;
   /** AI-чат в кабинете включён */
@@ -3508,6 +3527,7 @@ export interface PublicConfig {
   googleAnalyticsId?: string | null;
   yandexMetrikaId?: string | null;
   skipEmailVerification?: boolean;
+  loginEmailCodeEnabled?: boolean;
   useRemnaSubscriptionPage?: boolean;
   aiChatEnabled?: boolean;
   customBuildConfig?: {

--- a/frontend/src/pages/cabinet/client-login.tsx
+++ b/frontend/src/pages/cabinet/client-login.tsx
@@ -26,6 +26,8 @@ export function ClientLoginPage() {
   const { t } = useTranslation();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
+  const [mode, setMode] = useState<"password"|"email_code"|"forgot">("password");
   const [emailError, setEmailError] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
@@ -35,6 +37,7 @@ export function ClientLoginPage() {
   });
   const [telegramBotUsername, setTelegramBotUsername] = useState<string | null>(null);
   const [googleEnabled, setGoogleEnabled] = useState(false);
+  const [emailCodeEnabled, setEmailCodeEnabled] = useState(true);
   const [googleClientId, setGoogleClientId] = useState<string | null>(null);
   const [publicAppUrl, setPublicAppUrl] = useState<string | null>(null);
   const [appleEnabled, setAppleEnabled] = useState(false);
@@ -95,6 +98,7 @@ export function ClientLoginPage() {
         setTelegramBotUsername(c.telegramBotUsername ?? null);
         setTelegramBotId(c.telegramBotId ?? null);
         setGoogleEnabled(!!c.googleLoginEnabled);
+        setEmailCodeEnabled(c.loginEmailCodeEnabled !== false);
         setGoogleClientId(c.googleClientId ?? null);
         setPublicAppUrl(c.publicAppUrl ?? null);
         setAppleEnabled(!!c.appleLoginEnabled);
@@ -411,7 +415,17 @@ export function ClientLoginPage() {
     
     setLoading(true);
     try {
-      await login(email, password);
+      if (mode === "password") {
+        await login(email, password);
+      } else if (mode === "email_code") {
+        const res = await api.clientLoginByEmailCode(email, code);
+        if ("requires2FA" in res) throw new Error("2FA не поддерживается для этого входа");
+        localStorage.setItem("client_token", res.token);
+      } else {
+        await api.clientRequestPasswordReset(email);
+        setError("Ссылка для сброса отправлена на почту");
+        return;
+      }
       navigate("/cabinet", { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : t("cabinet.login.error_login"));
@@ -487,13 +501,19 @@ export function ClientLoginPage() {
                 />
                 {emailError && <p className="text-xs text-destructive">{emailError}</p>}
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="password">{t("cabinet.login.password_label")}</Label>
-                <Input id="password" type="password" name="login_password" value={password} onChange={(e) => setPassword(e.target.value)} required autoComplete="off" data-form-type="other" className="h-12 rounded-xl bg-background/50 backdrop-blur-sm border-white/10 focus-visible:ring-primary/50 transition-all" />
-              </div>
+              {mode !== "forgot" && <div className="space-y-2">
+                <Label htmlFor="password">{mode === "email_code" ? "Код из email" : t("cabinet.login.password_label")}</Label>
+                <Input id="password" type={mode === "email_code" ? "text" : "password"} name="login_password" value={mode === "email_code" ? code : password} onChange={(e) => mode === "email_code" ? setCode(e.target.value) : setPassword(e.target.value)} required autoComplete="off" data-form-type="other" className="h-12 rounded-xl bg-background/50 backdrop-blur-sm border-white/10 focus-visible:ring-primary/50 transition-all" />
+              </div>}
               <Button type="submit" className="w-full h-14 rounded-2xl text-base font-bold shadow-xl hover:scale-[1.02] transition-all gap-2" disabled={loading}>
-                {loading ? t("cabinet.login.submit_loading") : t("cabinet.login.submit")}
+                {loading ? t("cabinet.login.submit_loading") : mode === "forgot" ? "Отправить ссылку" : t("cabinet.login.submit")}
               </Button>
+              <div className="flex items-center justify-between text-sm">
+                {emailCodeEnabled ? <button type="button" className="text-primary" onClick={() => setMode(mode === "email_code" ? "password" : "email_code")}>{mode === "email_code" ? "Войти по паролю" : "Войти по коду из почты"}</button> : <span />}
+                <button type="button" className="text-primary" onClick={async () => { if (mode !== "forgot") { setMode("forgot"); return; } if (!emailCodeEnabled) return; await api.clientRequestEmailLoginCode(email); setMode("email_code"); }}>
+                  {mode === "forgot" ? "Отправить код входа" : "Забыли пароль?"}
+                </button>
+              </div>
               {(telegramBotUsername || googleEnabled || appleEnabled) && (
                 <div className="space-y-3">
                   <div className="relative flex items-center gap-2">

--- a/frontend/src/pages/cabinet/client-reset-password.tsx
+++ b/frontend/src/pages/cabinet/client-reset-password.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/lib/api";
+
+export function ClientResetPasswordPage() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token") || "";
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    if (!token) return setError("Некорректная ссылка");
+    if (password.length < 6) return setError("Минимум 6 символов");
+    if (password !== confirm) return setError("Пароли не совпадают");
+    setLoading(true);
+    try {
+      const res = await api.clientConfirmPasswordReset(token, password);
+      localStorage.setItem("client_token", res.token);
+      navigate("/cabinet", { replace: true });
+      window.location.reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Ошибка");
+    } finally { setLoading(false); }
+  }
+
+  return <div className="min-h-svh flex items-center justify-center p-4"><form onSubmit={onSubmit} className="w-full max-w-md space-y-4 rounded-3xl border bg-background/70 p-8 backdrop-blur">
+    <h1 className="text-2xl font-bold">Сброс пароля</h1>
+    {error && <div className="text-sm text-destructive">{error}</div>}
+    <div className="space-y-2"><Label>Новый пароль</Label><Input type="password" value={password} onChange={(e)=>setPassword(e.target.value)} required /></div>
+    <div className="space-y-2"><Label>Повторите пароль</Label><Input type="password" value={confirm} onChange={(e)=>setConfirm(e.target.value)} required /></div>
+    <Button className="w-full" disabled={loading}>{loading ? "Сохранение..." : "Подтвердить"}</Button>
+  </form></div>;
+}


### PR DESCRIPTION
Добавьте модели Prisma PendingEmailLoginCode и PendingPasswordReset, а также SQL-миграцию, которая создаст таблицы pending_email_login_codes и pending_password_resets с соответствующими индексами и ограничениями.
Реализуйте серверные конечные точки: POST /client/auth/login-email-code/request, POST /client/auth/login-email-code, POST /client/auth/password-reset/request и POST /client/auth/password-reset/confirm с хешированием одноразового кода (hashOneTime), генерацией токена, проверкой срока действия, увеличением количества попыток и отправкой электронного письма через sendEmail.
Добавьте login_email_code_enabled в системную конфигурацию (getSystemConfig) и общедоступную/административную конфигурацию, а также в обработку по умолчанию, и подключите флаг к использованию конфигурации во фронтенде/общедоступной конфигурации. 
 Изменения во фронтенде: новые методы API (clientRequestEmailLoginCode, clientLoginByEmailCode, clientRequestPasswordReset, clientConfirmPasswordReset), обновление ClientLoginPage для поддержки режимов ввода пароля, ввода кода с электронной почты и сброса пароля, добавление ClientResetPasswordPage и маршрута в App.tsx, а также обновление типов для включения loginEmailCodeEnabled.